### PR TITLE
Match URLs with fragments when rewriting links

### DIFF
--- a/src/Pimcore/Documentation/Console/PrepareCommand.php
+++ b/src/Pimcore/Documentation/Console/PrepareCommand.php
@@ -205,7 +205,7 @@ class PrepareCommand extends Command
             $contents = file_get_contents($file->getRealPath());
 
             // match all links to an internal README.md and rewrite them to _index.md
-            if (preg_match_all('/\[(?P<text>([^\]]*))\]\((?P<link>([^\)]*)README\.md)\)/', $contents, $matches, PREG_SET_ORDER)) {
+            if (preg_match_all('/\[(?P<text>(?:[^\]]*))\]\((?P<link>(?:[^\)]*)README\.md)(?:#[^\)]*)?\)/', $contents, $matches, PREG_SET_ORDER)) {
                 foreach ($matches as $match) {
                     // do not touch links with a scheme (e.g. external links to README.md files)
                     if (false !== strpos($match['link'], '://')) {


### PR DESCRIPTION
Sometimes it is desired to jump to a specific section of a page using a fragment identifier.

This generally works, but not for links to `README.md` files because the `prepare` command rewrites those links to point to `_index.md` instead (the `README.md` files were renamed in a previous step).

The regex used for this does not match links with fragment identifiers which results in an error when building the docs (as the link was not rewritten and still points to the old `README.md` and thus cannot be found).

This PR fixes this.

---

See https://github.com/pimcore/pimcore/pull/6986 for a failing case.