### PR TITLE
Link to current page version via <link rel="canonical">

### DIFF
--- a/themes/pimcore/templates/layout/00_layout.php
+++ b/themes/pimcore/templates/layout/00_layout.php
@@ -16,9 +16,22 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <!-- Font -->
-    <?php foreach ($params['theme']['fonts'] as $font) {
-    echo "<link href='$font' rel='stylesheet' type='text/css'>";
-} ?>
+    <?php 
+    foreach ($params['theme']['fonts'] as $font) {
+        echo "<link href='$font' rel='stylesheet' type='text/css'>";
+    }
+    
+    if(!empty($params['version_map'])) {
+        $versionMap = $params['version_map'];
+        if($versionMap['hasMultipleVersions'] && is_array($versionMap['versions']['Maintained'])) { 
+            foreach($versionMap['versions']['Maintained'] as $versionName => $version) {
+                if(strpos($versionName, 'current') !== false) {
+                    echo '<link rel="canonical" href="'.$params['version_switch_path_prefix'].'/'.$versionName ?>/<?= $page['request'] ?>">';
+                }
+            }
+        }
+    }
+?>
 
     <!-- CSS -->
     <?php foreach ($params['theme']['css'] as $css) {


### PR DESCRIPTION
Currently it happens that in Google an old documentation version is kept. 
This for example happens when googling for [pimcore update](https://www.google.com/search?client=firefox-b-d&q=pimcore+update), then there is a search result to https://pimcore.com/docs/pimcore/10.2/Development_Documentation/Installation_and_Upgrade/Updating_Pimcore/V6_to_V10.html - this is for branch 10.2 but meanwhile also 10.5 exists.

With this PR `<link rel="canonical" href="<URL to /current">` automatically gets added so that Google knows which page is to be preferred (as Google recognizes the different versions of a page as duplicate content).

Code is untested as I have no experience how to execute generation. I only copied some code from https://github.com/pimcore/pimcore-docs/blob/main/themes/pimcore/templates/partials/change_version.php to solve this.